### PR TITLE
linked PR to the package even if it's one of its deps that is failing

### DIFF
--- a/functions.R
+++ b/functions.R
@@ -1,0 +1,60 @@
+safe_packageRank <- function(...){
+  tryCatch(
+    packageRank::packageRank(...)$package.data,
+    error = function(e) NULL
+  )
+}
+
+get_prs <- function(state){
+
+  output_path <- paste0(state, "_prs.json")
+
+  # Run the command
+  system(paste0(
+    "gh pr list --state=", state,
+    " --search=rPackages -R NixOS/nixpkgs --json title,updatedAt,url > ", 
+    output_path
+  ))
+
+  # Return path for targets
+  output_path
+}
+
+clean_prs <- function(prs_raw, state){
+  prs_raw |>
+    transform(
+      title = gsub("^.*r(p|P)ackages\\.", "", title),
+      state = state
+    ) |>
+    transform(
+      # this name might be weird, but it's because
+      # it'll get merged with another data frame
+      fails_because_of = gsub(":.*$", "", title),
+      PR_date = updatedAt,
+      PR = paste0('<a href="', url, '">', url, '</a>')
+    ) |>
+    subset(
+      select = -c(title, url, updatedAt)
+    )
+}
+
+# Some packages fail because one of their deps (itself an R package)
+# fails to build. So if X is a dep of Y, and a PR to fix X is open
+# then I want that PR to be linked to Y.
+# This function will fetch the package that failed in the error message
+# on Hydra.
+get_failed_dep <- function(url){
+
+  read_url <- read_html(url)
+
+  # Get table
+  what <- html_table(
+    html_nodes(
+      read_url,
+      "[class = 'table table-striped table-condensed clickable-rows']"))[[1]] |>
+    subset(select = What)
+
+  # Clean string
+  gsub(".*-r-", "", what$What)  |>
+    gsub("-.*$", "", x=_)
+}

--- a/r-updates-fails.Rmd
+++ b/r-updates-fails.Rmd
@@ -8,15 +8,10 @@ format: html
 
 targets::tar_load(last_jobset_url)
 
-targets::tar_load(results_table_with_rank)
-targets::tar_load(prs_df)
+targets::tar_load(packages_df_with_rank)
 
 # if everything fails, stop here
-stopifnot("Table has error’d" = !is.null(results_table_with_rank))
-
-results_df <- subset(results_table_with_rank$package.data,
-                     select = c(-date, -total.downloads, -total.packages, -downloads))
-
+stopifnot("Table has error’d" = !is.null(packages_df_with_rank))
 
 ```
 
@@ -33,16 +28,14 @@ doesn't follow the naming convention "rPackages.packagename: blab bal" it likely
 won't show up here.
 
 ```{r, echo = FALSE}
-targets::tar_load(failing_jobs)
+targets::tar_load(final_results)
 
-merge(failing_jobs, results_df) |>
-  merge(prs_df, all.x = TRUE) |>  
-  subset(select = -`X.`) |> 
-  reactable::reactable(columns = list(build = reactable::colDef(html = TRUE),
-                                      PR = reactable::colDef(html = TRUE)),
-                       defaultSorted = "rank",
-                       filterable = TRUE
-   )
+reactable::reactable(final_results,
+  columns = list(build = reactable::colDef(html = TRUE),
+                 PR = reactable::colDef(html = TRUE)),
+  defaultSorted = "rank",
+  filterable = TRUE
+)
 
 ```
 


### PR DESCRIPTION
This PR does several things:

- general improves structure of the project
- but more importantly, now if the build of a package fails because one of its deps (also an R package) fails, then if a PR gets opened to fix the dependency, the PR gets linked to the package as well