### PR TITLE
Switch to hydra API

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -1,5 +1,6 @@
 library(targets)
 library(tarchetypes)
+library(httr2)
 
 tar_option_set(
   packages = c(
@@ -8,143 +9,52 @@ tar_option_set(
   )
 )
 
+base_url <- "https://hydra.vk3.wtf"
+req <- request(base_url)
+platforms <- c("x86_64-linux")
+
 source("functions.R")
 
 list(
   tar_target(
-    evaluations_url,
-    "https://hydra.vk3.wtf/jobset/nixpkgs/r-updates#tabs-evaluations"
-  ),
-
-  tar_force(
-    evaluations_tables,
-    read_html(evaluations_url),
-    force = TRUE
+    "hydra_evaluations",
+    get_hydra_evaluations(req = req)
   ),
 
   tar_target(
-    evaluations,
-    {
-      html_table(
-        html_nodes(
-          evaluations_tables,
-          "[class = 'table table-condensed table-striped clickable-rows']"
-        )
-      )[[1]] |>
-        subset(Date != "Date", select = `#`)
-    }
+    "latest_evaluation",
+    hydra_evaluations[[1]][["id"]]
   ),
 
   tar_target(
-    last_evaluation,
-    evaluations[1, "#"]
+    "hydra_builds",
+    get_hydra_builds(latest_evaluation)
   ),
 
   tar_target(
-    last_jobset_still_fail_url,
-    paste0(
-      "https://hydra.vk3.wtf/eval/",
-      last_evaluation,
-      "?full=1#tabs-still-fail#filter=x86"
-    )
+    "build_table",
+    build_build_table(hydra_builds)
   ),
 
   tar_target(
-    last_jobset_now_fail_url,
-    paste0(
-      "https://hydra.vk3.wtf/eval/",
-      last_evaluation,
-      "?full=1#tabs-now-fail#filter=x86"
-    )
-  ),
-
-  tar_target(
-    still_failing_jobs_html,
-    read_html(last_jobset_still_fail_url)
-  ),
-
-  tar_target(
-    now_failing_jobs_html,
-    read_html(last_jobset_now_fail_url)
-  ),
-
-  tar_target(
-    still_failing_jobs_raw,
-    html_table(html_nodes(
-      still_failing_jobs_html,
-      "[id = 'tabs-still-fail']"
-    ))[[1]]
-  ),
-
-  tar_target(
-    now_failing_jobs_raw,
-    html_table(html_nodes(now_failing_jobs_html, "[id = 'tabs-now-fail']"))[[1]]
-  ),
-
-  tar_target(
-    failing_jobs_raw,
-    rbind(now_failing_jobs_raw, still_failing_jobs_raw)
-  ),
-
-  tar_target(
-    failing_jobs_raw_clean,
-    subset(
-      failing_jobs_raw,
-      subset = !grepl("builds omitted", System),
-      select = c("#", "Finished at", "Package/release name", "System")
-    ) |>
-      transform(packages = gsub("^r-", "", `Package/release name`)) |>
-      transform(packages = gsub("-.*$", "", packages)) |>
-      transform(build = paste0("https://hydra.vk3.wtf/build/", "#")) |>
-      transform(`Finished at` = convert_hours_days(`Finished at`))
-  ),
-
-  tar_target(
-    failing_jobs_with_deps,
-    transform(
-      failing_jobs_raw_clean,
-      #fails_because_of = ""
-      # is too slow of Justin’s instance
-      fails_because_of = sapply(build, safe_get_failed_dep)
-    ) |>
-      transform(
-        fails_because_of = ifelse(
-          grepl("Build of .nix.store", fails_because_of),
-          "",
-          fails_because_of
-        )
-      ) |>
-      transform(
-        fails_because_of = ifelse(
-          fails_because_of == "",
-          packages,
-          fails_because_of
-        )
-      )
-  ),
-
-  tar_target(
-    failing_jobs,
-    transform(
-      failing_jobs_with_deps,
-      build = paste0('<a href="', build, '">', build, '</a>')
-    )
+    "failing_builds",
+    get_failing_jobs(build_table, platforms)
   ),
 
   tar_target(
     latest_eval_date,
-    max(failing_jobs$`Finished.at`)
+    max(strptime(build_table[["end_time"]], "%s", tz = "UTC"), na.rm = TRUE)
   ),
 
   tar_target(
     unique_packages,
-    unique(failing_jobs$packages)
+    unique(failing_builds[["name"]])
   ),
 
   tar_target(
     packages_df_with_rank,
     safe_packageRank(packages = unique_packages) |>
-      subset(select = c(-date, -total.downloads, -total.packages, -downloads))
+      subset(select = c("package", "percentile"))
   ),
 
   tar_target(
@@ -185,7 +95,7 @@ list(
     rbind(open_prs, merged_prs) |>
       subset(
         #subset = state != "merged",
-        select = c("fails_because_of", "PR", "PR_date", "state"),
+        select = c("name", "PR", "PR_date", "state"),
         PR_date > as.Date("2024-05-10") # change this date manually to avoid having
         # merged PRs listed from old fixes. This happens
         # if packages fail again
@@ -194,7 +104,7 @@ list(
 
   tar_target(
     failing_jobs_with_prs,
-    merge(failing_jobs, prs_df, all.x = TRUE)
+    merge(failing_builds, prs_df, all.x = TRUE)
   ),
 
   # Bioconductor rank
@@ -206,29 +116,32 @@ list(
 
   tar_target(
     bioc_pkg_scores.tab,
-    read.csv(bioc_pkg_scores.tab_path, sep = "\t") |>
-      subset(Package != "monocle")
+    build_bioc_table(bioc_pkg_scores.tab_path)
   ),
 
   tar_target(
     bioc_pkg_failing,
     bioc_pkg_scores.tab |>
       subset(subset = (Package %in% unique_packages)) |>
-      transform(fails_because_of = Package, rank = Download_score) |>
-      subset(select = c(fails_because_of, rank))
+      transform(name = Package) |>
+      subset(select = c(name, percentile))
   ),
 
   tar_target(
     final_results,
-    merge(failing_jobs_with_prs, packages_df_with_rank) |>
+    merge(
+      failing_jobs_with_prs,
+      packages_df_with_rank,
+      by.x = "name",
+      by.y = "package"
+    ) |>
       subset(
         select = c(
-          packages,
-          fails_because_of,
-          `Finished at`,
-          System,
-          build,
-          rank,
+          name,
+          nixname,
+          system,
+          status,
+          log_link,
           percentile,
           PR,
           PR_date,
@@ -239,15 +152,15 @@ list(
 
   tar_target(
     final_results_bioc,
-    merge(failing_jobs_with_prs, bioc_pkg_failing) |>
+    merge(failing_jobs_with_prs, bioc_pkg_failing, by = "name") |>
       subset(
         select = c(
-          packages,
-          fails_because_of,
-          `Finished at`,
-          System,
-          build,
-          rank,
+          name,
+          nixname,
+          system,
+          status,
+          log_link,
+          percentile,
           PR,
           PR_date,
           state

--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,5 @@
 let
- pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/ded3e593909ec35bbdef0335c313afeebe826470.tar.gz") {};
+ pkgs = import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/32f313e49e42f715491e1ea7b306a87c16fe0388.tar.gz") {};
  system_packages = builtins.attrValues {
   inherit (pkgs) gh glibcLocalesUtf8 pandoc nix R   ;
 };
@@ -14,7 +14,8 @@ let
     LC_MEASUREMENT = "en_US.UTF-8";
 
     buildInputs = [
-      system_packages      
+      system_packages
+      pkgs.rPackages.httr2
       pkgs.rPackages.jsonlite
       pkgs.rPackages.knitr
       pkgs.rPackages.packageRank
@@ -23,6 +24,7 @@ let
       pkgs.rPackages.rvest
       pkgs.rPackages.tarchetypes
       pkgs.rPackages.targets
+      pkgs.rPackages.visNetwork
                   ];
 
   }

--- a/functions.R
+++ b/functions.R
@@ -1,42 +1,49 @@
-safe_packageRank <- function(...){
+safe_packageRank <- function(...) {
   tryCatch(
     packageRank::packageRank(...)$package.data,
     error = function(e) NULL
   )
 }
 
-get_prs <- function(state){
-
+get_prs <- function(state) {
   output_path <- paste0(state, "_prs.json")
 
-                                        # Run the command
+  # Run the command
   system(paste0(
-    "gh pr list --limit=100 --state=", state,
-    " --search=rPackages -R NixOS/nixpkgs --json title,updatedAt,url > ", 
+    "gh pr list --limit=100 --state=",
+    state,
+    " --search=rPackages -R NixOS/nixpkgs --json title,updatedAt,url > ",
     output_path
   ))
 
-                                        # Return path for targets
+  # Return path for targets
   output_path
 }
 
-get_bioc_pkgs_score <- function(){
-
-  system("wget https://bioconductor.org/packages/stats/bioc/bioc_pkg_scores.tab")
+get_bioc_pkgs_score <- function() {
+  system(
+    "wget https://bioconductor.org/packages/stats/bioc/bioc_pkg_scores.tab"
+  )
 
   "bioc_pkg_scores.tab"
 }
 
-clean_prs <- function(prs_raw, state){
+build_bioc_table <- function(path) {
+  orig <- read.csv(path, sep = "\t") |>
+    subset(Package != "monocle")
+  ranks <- rank(orig[["Download_score"]])
+  orig[["percentile"]] <- round(ranks / max(ranks, na.rm = TRUE) * 100)
+  orig
+}
+
+clean_prs <- function(prs_raw, state) {
   prs_raw |>
     transform(
       title = gsub("^.*r(p|P)ackages\\.", "", title),
       state = state
     ) |>
     transform(
-      # this name might be weird, but it's because
-      # it'll get merged with another data frame
-      fails_because_of = gsub(":.*$", "", title),
+      name = gsub(":.*$", "", title),
       PR_date = updatedAt,
       PR = paste0('<a href="', url, '">', url, '</a>')
     ) |>
@@ -50,36 +57,36 @@ clean_prs <- function(prs_raw, state){
 # then I want that PR to be linked to Y.
 # This function will fetch the package that failed in the error message
 # on Hydra.
-get_failed_dep <- function(url){
-
+get_failed_dep <- function(url) {
   read_url <- read_html(url)
 
   # Get table
   what <- html_table(
     html_nodes(
       read_url,
-      "[class = 'table table-striped table-condensed clickable-rows']"))[[1]] |>
+      "[class = 'table table-striped table-condensed clickable-rows']"
+    )
+  )[[1]] |>
     subset(select = What)
 
   # Clean string
-  gsub(".*-r-", "", what$What)  |>
-    gsub("-.*$", "", x=_) |>
+  gsub(".*-r-", "", what$What) |>
+    gsub("-.*$", "", x = _) |>
     paste(collapse = "_")
 }
 
-safe_get_failed_dep <- function(...){
+safe_get_failed_dep <- function(...) {
   tryCatch(
     get_failed_dep(...),
     error = function(e) ""
   )
 }
 
-convert_hours_days <- function(many_dates){
-
-  one_date <- function(a_date){
-    if(grepl("\\d{1}d ago", a_date)){
+convert_hours_days <- function(many_dates) {
+  one_date <- function(a_date) {
+    if (grepl("\\d{1}d ago", a_date)) {
       as.character(Sys.Date() - as.numeric(gsub("d ago", "", a_date)))
-    } else if(grepl("\\d{1}h ago", a_date)){
+    } else if (grepl("\\d{1}h ago", a_date)) {
       as.character(Sys.Date())
     } else {
       as.character(a_date)
@@ -88,5 +95,91 @@ convert_hours_days <- function(many_dates){
 
   lapply(many_dates, one_date) |>
     unlist()
+}
 
+
+# This has to work on a vector of length 1, because
+# buildstatus is either NULL or integer
+# https://github.com/NixOS/hydra/blob/master/hydra-api.yaml#L949
+translate_buildstatus <- function(x) {
+  dict <- c(
+    "succeeded", #0
+    "failed", #1
+    "dependency failed", #2
+    "aborted", #3
+    "canceled by the user", #4
+    NA,
+    "failed with output", #6
+    "timed out", #7
+    NA,
+    "aborted", #9
+    "log size limit exceeded", #10
+    "output size limit exceeded" #11
+  )
+  res <- if (is.null(x)) "unfinished" else dict[x + 1]
+  if (is.na(res) || length(res) < 1L) {
+    res <- "failed"
+  }
+  return(res)
+}
+
+get_hydra_evaluations <- function(req, jobset = "r-updates") {
+  resp_evals <- req |>
+    req_url_path_append(
+      paste0("jobset/nixpkgs/", jobset, "/evals")
+    ) |>
+    req_headers(Accept = "application/json") |>
+    req_perform()
+
+  evals <- resp_body_json(resp_evals)[["evals"]]
+  stopifnot(length(evals) > 0L)
+  evals
+}
+
+get_hydra_builds <- function(eval_id) {
+  storage <- tempfile(pattern = "evals_", fileext = ".json")
+  resp_builds <- req |>
+    req_url_path_append("eval", eval_id, "builds") |>
+    req_headers(Accept = "application/json") |>
+    req_perform(verbosity = 1, path = storage)
+  resp_body_json(resp_builds)
+}
+
+build_build_table <- function(builds) {
+  as.data.frame(t(vapply(
+    builds,
+    \(x) {
+      c(
+        name = sub("^rPackages\\.", "", x[["job"]]) |>
+          sub(
+            pattern = paste0("\\.", paste(platforms, collapse = "|"), "$"),
+            replacement = ""
+          ),
+        nixname = x[["nixname"]],
+        system = x[["system"]],
+        status = translate_buildstatus(x[["buildstatus"]]),
+        log_link = as.character(htmltools::tags$a(
+          href = paste0(base_url, "/build/", x[["id"]], "/log/raw"),
+          target = "_blank",
+          paste0("build ", x[["id"]])
+        )),
+        end_time = x[["stoptime"]]
+      )
+    },
+    FUN.VALUE = c(
+      "valami",
+      "r-valami",
+      "x86-64_linux",
+      "0",
+      "http://a.x.com",
+      "0"
+    )
+  )))
+}
+
+get_failing_jobs <- function(x, platforms) {
+  these <- with(x, {
+    x[system %in% platforms & !(grepl("succeeded|unfinished", status)), ]
+  })
+  sort_by(these, these[["status"]])
 }

--- a/r-updates-fails.Rmd
+++ b/r-updates-fails.Rmd
@@ -8,7 +8,11 @@ format:
 
 ```{r, include = FALSE}
 
-targets::tar_load(last_jobset_still_fail_url)
+eval_web_url <- paste(
+    base_url,
+    "eval",
+    targets::tar_read(latest_evaluation), sep = "/"
+) 
 
 targets::tar_load(packages_df_with_rank)
 
@@ -17,17 +21,14 @@ stopifnot("Table has error’d" = !is.null(packages_df_with_rank))
 
 ```
 
-The table below can be found at `r last_jobset_still_fail_url`, but here it
-includes the rank of the package as computed by the `{packageRank}` package, as
-well as a link to the PR to fix the build if it has been opened or if it's been
-merged already. In the case of Bioconductor packages, package rank is directly
-obtained from [this
-csv](https://bioconductor.org/packages/stats/bioc/bioc_pkg_scores.tab) and the
-rank is actually the monthly average of unique IP adresses that download the
-package, so the higher, the better. If a package doesn't build because one of
-its dependencies is broken, and if a PR fixing the broken dependency has been
-opened, then each package that depends upon this dependency gets linked to said
-PR.
+The tables below are a result of the hydra evaluation `r eval_web_url`, 
+(latest build: `r strftime(targets::tar_read(latest_eval_date), usetz = TRUE)`).
+Here, they include the
+percentile of the package as computed by the `{packageRank}` package, as well as
+a link to the PR to fix the build if it has been opened or if it's been merged
+already. In the case of Bioconductor packages, percentile is calculated based on
+the download count from here
+[this csv](https://bioconductor.org/packages/stats/bioc/bioc_pkg_scores.tab).
 
 The action generating the website runs each day at midnight. Do check the
 original on Hydra from time to time though, because I can't guarantee that all
@@ -35,34 +36,33 @@ packages do show here. They should, but who knows. If the pull request fixing
 the package doesn't follow the naming convention "rPackages.packagename: blab
 bal" it likely won't show up here.
 
-This is the table for CRAN packages. The lower the rank, the more popular the
-package:
+This is the table for CRAN packages. The greater the percentile, the more
+popular the package:
 
-```{r, echo = FALSE}
+```{r echo=FALSE, message=FALSE}
 targets::tar_load(final_results)
 
 reactable::reactable(final_results,
-  columns = list(build = reactable::colDef(html = TRUE),
-                 PR = reactable::colDef(html = TRUE)),
-  defaultSorted = "rank",
+  columns = list(log_link = reactable::colDef(html = TRUE),
+                 PR = reactable::colDef(html = TRUE),
+                 percentile = reactable::colDef(defaultSortOrder = "desc")),
+  defaultSorted = "percentile",
   filterable = TRUE
 )
 
 ```
 
-This is the table for Bioconductor packages. The rank is what they call the
-*download score* which is *the average number of distinct IPs that "hit" the
-package each month for the last 12 months (not counting the current month)*, so
-the higher the rank, the more popular that package is:
+This is the table for Bioconductor packages. The greater the percentile, the 
+more popular the package.
 
-```{r, echo = FALSE}
+```{r, echo=FALSE, message=FALSE}
 targets::tar_load(final_results_bioc)
 
 reactable::reactable(final_results_bioc,
-  columns = list(build = reactable::colDef(html = TRUE),
+  columns = list(log_link = reactable::colDef(html = TRUE),
                  PR = reactable::colDef(html = TRUE),
-                 rank = reactable::colDef(defaultSortOrder = "desc")),
-  defaultSorted = "rank",
+                 percentile = reactable::colDef(defaultSortOrder = "desc")),
+  defaultSorted = "percentile",
   filterable = TRUE
 )
 


### PR DESCRIPTION
- Use hydra API instead of web
- Use percentiles for both Bioc and CRAN (more comparable)
- Link to logs
- Don't track failing deps (see below)

Easier to get the build evals, and build status is more informative. However, we can't get failing dep info from the API, but we could if needed,. Packages with deps should rank higher in the percentiles, so they should be fixed first anyway.