### PR TITLE
Omit unfinished evaluations

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -28,7 +28,7 @@ list(
 
   tar_target(
     "latest_evaluation",
-    hydra_evaluations[[1]][["id"]]
+    get_latest_evaluation(hydra_evaluations)
   ),
 
   tar_target(


### PR DESCRIPTION
Use the latest *completed* evaluation, in case the pipeline runs while a hydra evaluation is ongoing.