### PR TITLE
Fix bioc status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ r-updates-fails_files/
 *.json
 *.tab
 result
+.Rproj.user
+*.Rproj
+.Rhistory
+.envrc
+.direnv
+bioc_pkg_scores.tab*

--- a/_targets.R
+++ b/_targets.R
@@ -170,7 +170,7 @@ list(
 
   tar_target(
     "bioc_build_status_tbl",
-    BiocPkgTools::biocBuildStatusDB()
+    BiocPkgTools::biocBuildStatusDB(version = "release")
   ),
 
   tar_target(

--- a/_targets.R
+++ b/_targets.R
@@ -10,10 +10,11 @@ tar_option_set(
 )
 base_url <- "https://hydra.vk3.wtf"
 req <- request(base_url)
-platforms <- c("x86_64-linux")
 source("functions.R")
 
 list(
+  tar_target("platforms", "x86_64-linux"),
+
   tar_target(
     "hydra_evaluations",
     get_hydra_evaluations(req = req)
@@ -31,7 +32,7 @@ list(
 
   tar_target(
     "build_table",
-    build_build_table(hydra_builds)
+    build_build_table(hydra_builds, platforms)
   ),
 
   tar_target(

--- a/functions.R
+++ b/functions.R
@@ -206,7 +206,7 @@ get_hydra_builds <- function(eval_id) {
   resp_body_json(resp_builds)
 }
 
-build_build_table <- function(builds) {
+build_build_table <- function(builds, platforms) {
   as.data.frame(t(vapply(
     builds,
     \(x) {


### PR DESCRIPTION
The modification in this PR queries the _current_ release status

By default, the version is determined by BiocManager::version().
If it doesn't match the target release, it can return the wrong builder
names, and the status column will fail. The value "release" will always point to the latest release, which is what we want in most cases.